### PR TITLE
Deprecate package in favor of ros-sports/soccer_vision_3d_rviz_markers

### DIFF
--- a/soccer_marker_generation/package.xml
+++ b/soccer_marker_generation/package.xml
@@ -19,5 +19,9 @@
 
   <export>
     <build_type>ament_cmake</build_type>
+    <deprecated>
+      This package will be removed in ROS J-Turtle due to the deprecation of soccer_object_msgs package.
+      Instead, use packages from ros-sports/soccer_vision_3d_rviz_markers, which provides similar features with a different API.
+    </deprecated>
   </export>
 </package>


### PR DESCRIPTION
Deprecating package due to deprecation of soccer_object_msgs in https://github.com/ijnek/soccer_object_msgs/pull/13.
A replacement package that provides akin functionality would be [ros-sports/soccer_vision_3d_rviz_markers](https://github.com/ros-sports/soccer_vision_3d_rviz_markers)